### PR TITLE
Split admin endpoints functionality

### DIFF
--- a/src/model/requestModel.go
+++ b/src/model/requestModel.go
@@ -56,21 +56,24 @@ type UpdateUserRequest struct {
 // Admin Endpoints
 
 type RegisterAdminRequest struct {
-	ApiKey string `header:"X-INIT-ADMIN-API-KEY"`
-	Body   struct {
-		FirstName       string `json:"firstName" example:"John" doc:"User first name"`
-		LastName        string `json:"lastName" example:"Doe" doc:"User last name"`
-		DiscordUsername string `json:"discordUsername" example:"JohnDoe" doc:"Username in InIT discord server"`
-		Email           string `json:"email" example:"john.doe@example.com" doc:"User email, the confirmation will be send to that adress"`
-		Password        string `json:"password" example:"Pa$$word123!" doc:"User Password"`
+	ApiKey    string      `header:"X-INIT-ADMIN-API-KEY"`
+	JwtCookie http.Cookie `cookie:"jwt-init-admin"`
+
+	Body struct {
+		Email string `json:"email" example:"john.doe@example.com" doc:"User email, the confirmation will be send to that adress"`
 	}
 }
 
 type VerificationAdminRequest struct {
 	ApiKey string `header:"X-INIT-ADMIN-API-KEY"`
-	Body   struct {
+
+	Body struct {
 		Email             string `json:"email" example:"john.doe@example.com" doc:"Admin email already registered to InIT backend"`
 		VerificationToken string `json:"verificationToken" example:"d4f8c767-8e92-4504-8565-3369d78dbc30" doc:"Unique token genereated for each admin user in registration provided in link as token"`
+		FirstName         string `json:"firstName" example:"John" doc:"Admin first name"`
+		LastName          string `json:"lastName" example:"Doe" doc:"Admin last name"`
+		DiscordUsername   string `json:"discordUsername" example:"JohnDoe" doc:"Admin username in InIT discord server"`
+		Password          string `json:"password" example:"Pa$$word123!" doc:"User Password"`
 	}
 }
 
@@ -90,5 +93,5 @@ type LogoutAdminRequest struct {
 type GetAdminRequest struct {
 	ApiKey    string      `header:"X-INIT-ADMIN-API-KEY"`
 	JwtCookie http.Cookie `cookie:"jwt-init-admin"`
-	Id        string      `path:"id" example:"67c0df2b24397b2e860be392" doc:"requested user id"`
+	Id        string      `path:"id" example:"67c0df2b24397b2e860be392" doc:"requested admin id"`
 }

--- a/src/server/register-server.go
+++ b/src/server/register-server.go
@@ -185,7 +185,7 @@ func addAdminRoutes(api huma.API, handler handler.AdminHandler, apiKey string) {
 		Path:        "/register/admin",
 		Summary:     "Register admin",
 		Description: "Register admin and send confirmation email to provided adress with unique token for account verification",
-		Middlewares: huma.Middlewares{apiKeyMiddleware},
+		Middlewares: huma.Middlewares{apiKeyMiddleware, authMiddleware},
 	}, handler.HandleRegisterAdminRequest)
 
 	huma.Register(api, huma.Operation{
@@ -193,7 +193,7 @@ func addAdminRoutes(api huma.API, handler handler.AdminHandler, apiKey string) {
 		Method:      http.MethodPost,
 		Path:        "/register/admin/verifiy",
 		Summary:     "Verify admin email",
-		Description: "Based on provided token and email, verify the admin email",
+		Description: "Based on provided token and email, verify the admin email and update admin data",
 		Middlewares: huma.Middlewares{apiKeyMiddleware},
 	}, handler.HandleVerificationAdminRequest)
 

--- a/src/service/emailService.go
+++ b/src/service/emailService.go
@@ -158,7 +158,7 @@ func (srv EmailService) fillTemplate(emailTmpl model.EmailTemplate, templModel m
 func (srv EmailService) SendAdminVerificationEmail(ctx context.Context, admin model.Admin) error {
 	defer srv.service.logger.Sync()
 
-	templateName := "icc_account_verification"
+	templateName := "admin_verification"
 
 	emailTmpl, err := srv.repository.GetSingleTemplateByName(templateName, ctx)
 	if err != nil {


### PR DESCRIPTION
Register endpoint create admin and send verification email, all admin data is updated in verification step.
Now only admins can create admin (additional cookie verification)